### PR TITLE
FEAT : #48 register error handle using snackbar

### DIFF
--- a/src/views/auth/register/register.tsx
+++ b/src/views/auth/register/register.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useState } from "react";
 import { Redirect } from "react-router-dom";
 import Header from "../../../components/header/header";
+import snackbar from "../../../components/snackbar/snackbar";
 import "./register.scss";
 
 function Register() {
@@ -40,14 +41,19 @@ function Register() {
           }
         )
         .then((response) => {
-          console.log("registered!");
           setRegisted(true);
+        })
+        .catch(error => {
+          if (error.response.data.statusCode === 403) {
+            setForbiddenError(true);
+            snackbar.error("잘못된 접근입니다.");
+          }
+          else if (error.response.data.statusCode === 400) {
+            snackbar.error("닉네임이 중복되었습니다. 다시 시도해주세요.");
+          }
         });
-    } catch (error) {
-      //forbidden (already existed user)
-      console.log("error! redirect to main.");
-      setForbiddenError(true);
-    }
+    } catch (error) {};
+
     setForm({
       nickname: "",
     });


### PR DESCRIPTION
## 작업 내용

#48 에 해당하는 내용을 구현했습니다.

* 403 : 이미 userDB에 있는 상태에서 클라이언트가 임의로 /register path로 접근한 뒤 post 요청을 보내면 뜨는 에러입니다. 아래와 같이 snackbar가 뜬 뒤, main으로 redirect 됩니다.
![register](https://user-images.githubusercontent.com/20695892/137007552-fa00096e-1eb5-460f-a31a-5213ae7c9434.PNG)
![register_403](https://user-images.githubusercontent.com/20695892/137007559-bc2baf20-2d63-4306-94be-525d321d6073.PNG)

* 400 : 신규 유저가 post 요청을 보냈을 때 이미 중복된 닉네임이 있는 경우에 뜨는 에러입니다. 아래와 같이 snackbar가 뜨며, 다시 입력을 받게 됩니다.
![register_400](https://user-images.githubusercontent.com/20695892/137007579-271c1e11-b3d1-488c-898a-8d9fec9f1f93.PNG)

close #48 
## 공유 사항

서버에서는 잘 에러 핸들링을 해주고 있어서 front에서 적절히 처리해줬습니다.